### PR TITLE
To avoid peerDependencies problems with npm 1 or 2 and react ^x.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,6 +23,6 @@
   },
   "homepage": "https://github.com/captivationsoftware/react-global",
   "peerDependencies": {
-    "react": "0.x"
+    "react": "0.x || ^x.0.0"
   }
 }


### PR DESCRIPTION
Hello,

I cloned my project in a machine with npm 2.15.1 , all was installed as expected on my node_modules folder but at the end I had this error :

```
Binary is fine; exiting.
npm ERR! Windows_NT 6.1.7601
npm ERR! argv "C:\\Program Files\\nodejs\\node.exe" "C:\\Program Files\\nodejs\\
node_modules\\npm\\bin\\npm-cli.js" "install"
npm ERR! node v4.4.4
npm ERR! npm  v2.15.1
npm ERR! code EPEERINVALID

npm ERR! peerinvalid The package react@15.0.2 does not satisfy its siblings' pee
rDependencies requirements!
npm ERR! peerinvalid Peer express-react-views@0.10.1 wants react@^0.14.0 || ^15.
0.0
npm ERR! peerinvalid Peer react-addons-create-fragment@15.0.2 wants react@^15.0.
2
npm ERR! peerinvalid Peer react-addons-update@15.0.2 wants react@^15.0.2
npm ERR! peerinvalid Peer react-dom@15.0.2 wants react@^15.0.2
npm ERR! peerinvalid Peer react-global@0.1.8 wants react@0.x
npm ERR! peerinvalid Peer react-google-maps@4.10.1 wants react@^0.14.0 || ^15.0.
0
npm ERR! peerinvalid Peer react-router@2.4.0 wants react@^0.14.0 || ^15.0.0

npm ERR! Please include the following file with any support request:
npm ERR!     C:\dev\bcp-bot-web\npm-debug.log

```

A method to solve it is to add the current react version format to the peerDependencies section of the module.

```
"peerDependencies": {
    "react": "0.x || ^x.0.0"
  }
```
